### PR TITLE
Only run test suite workflow for changes to src or test

### DIFF
--- a/.github/workflows/CTCI_solutions_integrity.yml
+++ b/.github/workflows/CTCI_solutions_integrity.yml
@@ -2,7 +2,7 @@ name: CTCI Solutions Integrity Check
 
 on:
   push:
-    branches: [master, practice, config]
+    branches: [master, practice]
   pull_request:
     branches: [master]
 

--- a/.github/workflows/CTCI_solutions_integrity.yml
+++ b/.github/workflows/CTCI_solutions_integrity.yml
@@ -1,8 +1,11 @@
 name: CTCI Solutions Integrity Check
 
 on:
+  paths:
+    - 'CTCIPythonPlayground/src/*'
+    - 'CTCIPythonPlayground/test/*'
   push:
-    branches: [practice, ci-cd-setup]
+    branches: [master, practice, config]
   pull_request:
     branches: [master]
 

--- a/.github/workflows/CTCI_solutions_integrity.yml
+++ b/.github/workflows/CTCI_solutions_integrity.yml
@@ -1,9 +1,6 @@
 name: CTCI Solutions Integrity Check
 
 on:
-  paths:
-    - 'CTCIPythonPlayground/src/*'
-    - 'CTCIPythonPlayground/test/*'
   push:
     branches: [master, practice, config]
   pull_request:


### PR DESCRIPTION
# Context
The `config` branch is a branch solely for upgrading the CI/CD workflow - it does not require testing via the `pytest` test suite. 

# Changes
Have removed `config` branch as a branch for which test suite needs to run